### PR TITLE
feat(icrc1_oracle): record per-user anonymous principals for discover…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
- "opaque-debug",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,130 +133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener 5.3.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,12 +142,6 @@ dependencies = [
  "quote",
  "syn 2.0.79",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -506,7 +364,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -517,35 +374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-modes"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
-dependencies = [
- "block-padding",
- "cipher",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel 2.3.1",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -931,15 +759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,15 +850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,15 +886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc-any"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73"
-dependencies = [
- "debug-helper",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,12 +893,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -1315,12 +1110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debug-helper"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
-
-[[package]]
 name = "delegation_factory"
 version = "0.1.0"
 dependencies = [
@@ -1391,17 +1180,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "des"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac41dd49fb554432020d52c875fc290e110113f864c6b1b525cd62c7e7747a5d"
-dependencies = [
- "byteorder",
- "cipher",
- "opaque-debug",
 ]
 
 [[package]]
@@ -1575,33 +1353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "5.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
-dependencies = [
- "event-listener 5.3.1",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,19 +1484,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,18 +1571,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "group"
@@ -3012,7 +2738,6 @@ name = "identity_manager"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "base64 0.22.1",
  "candid 0.10.14",
@@ -3030,7 +2755,6 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "log",
- "magic-crypt",
  "mockers",
  "rand_chacha",
  "rand_core 0.6.4",
@@ -3282,15 +3006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lalrpop"
 version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,9 +3137,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "logos"
@@ -3482,38 +3194,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "magic-crypt"
-version = "3.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c42f95f9d296f2dcb50665f507ed5a68a171453142663ce44d77a4eb217b053"
-dependencies = [
- "aes",
- "base64 0.21.7",
- "block-modes",
- "crc-any",
- "des",
- "digest 0.9.0",
- "md-5",
- "sha2 0.9.9",
- "tiger",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "md-5"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
-]
 
 [[package]]
 name = "memchr"
@@ -3768,12 +3452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3874,17 +3552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,21 +3583,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.4.0",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4775,17 +4427,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
-name = "tiger"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443e531cbcf9de83258cfef70bcd56c91188de5819ebd4b19c85f589e0617005"
-dependencies = [
- "block-buffer 0.9.0",
- "byteorder",
- "digest 0.9.0",
-]
-
-[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4896,22 +4537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
-
-[[package]]
 name = "tree-deserializer"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic?rev=e69bcc7b319cbb3ebc22ec55af35287741244db6#e69bcc7b319cbb3ebc22ec55af35287741244db6"
@@ -5009,12 +4634,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
-name = "value-bag"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
-
-[[package]]
 name = "vault"
 version = "0.1.0"
 dependencies = [
@@ -5092,18 +4711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5131,16 +4738,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
-
-[[package]]
-name = "web-sys"
-version = "0.3.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "winapi"

--- a/admin_oracle/discovery/discovery.service.ts
+++ b/admin_oracle/discovery/discovery.service.ts
@@ -27,7 +27,17 @@ export class DefaultDiscoveryService implements DiscoveryService {
   }
 
   private async fetchPage(url: string): Promise<string> {
-    const response = await fetch(url);
+    // Identify as a real browser so Cloudflare and similar gateways serve
+    // the actual page instead of an anti-bot challenge.
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+      },
+    });
     return response.text();
   }
 

--- a/src/icrc1_oracle/icrc1_oracle.did
+++ b/src/icrc1_oracle/icrc1_oracle.did
@@ -93,6 +93,12 @@ type DiscoveryVisitRequest = record {
     derivation_origin : opt text;
     hostname : text;
     login : LoginType;
+    anonymous_principal : opt principal;
+};
+
+type UserDiscoveryApp = record {
+    app_id : nat32;
+    anonymous_principal : text;
 };
 
 type PromotionConfig = record {
@@ -162,6 +168,7 @@ service : (opt Conf) -> {
     btc_select_user_utxos_fee : (SelectedUtxosFeeRequest) -> (BtcSelectUserUtxosFeeResult);
     store_discovery_app : (DiscoveryVisitRequest) -> ();
     is_unique : (DiscoveryVisitRequest) -> (bool) query;
+    get_my_discovery_apps : () -> (vec UserDiscoveryApp);
     get_discovery_app_paginated : (nat64, nat64) -> (vec DiscoveryApp) query;
     replace_all_discovery_app : (vec DiscoveryApp) -> ();
     clear_discovery_apps : () -> ();

--- a/src/icrc1_oracle/src/lib.rs
+++ b/src/icrc1_oracle/src/lib.rs
@@ -174,6 +174,13 @@ pub struct DiscoveryVisitRequest {
     pub derivation_origin: Option<String>,
     pub hostname: String,
     pub login: LoginType,
+    pub anonymous_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Serialize, Debug)]
+pub struct UserDiscoveryApp {
+    pub app_id: u32,
+    pub anonymous_principal: String,
 }
 
 // ── Promotion (Discovery Monetization) ─────────────────────────────────────
@@ -285,6 +292,8 @@ thread_local! {
     pub static DISCOVERY_REGISTRY: RefCell<HashSet<DiscoveryApp>> = RefCell::new(HashSet::default());
     // Key: app id, Value: set of root_id strings (unique visitors per app)
     pub static DISCOVERY_VISITORS: RefCell<HashMap<u32, HashSet<String>>> = RefCell::new(HashMap::new());
+    // Key: root_id, Value: app id -> anonymous principal (text) the user uses for that app.
+    pub static DISCOVERY_USER_PRINCIPALS: RefCell<HashMap<String, HashMap<u32, String>>> = RefCell::new(HashMap::new());
     pub static PROMOTION_CONFIG: RefCell<Option<PromotionConfig>> = RefCell::new(None);
     pub static FEATURED_SLOT: RefCell<Option<FeaturedSlot>> = RefCell::new(None);
     pub static BID_HISTORY: RefCell<Vec<HistoricalBid>> = RefCell::new(Vec::new());
@@ -449,7 +458,7 @@ pub async fn store_discovery_app(request: DiscoveryVisitRequest) {
             .borrow_mut()
             .entry(app.id)
             .or_insert_with(HashSet::new)
-            .insert(root_id)
+            .insert(root_id.clone())
     });
 
     if is_new_visitor {
@@ -460,6 +469,15 @@ pub async fn store_discovery_app(request: DiscoveryVisitRequest) {
         LoginType::Global if !app.is_global => app.is_global = true,
         LoginType::Anonymous if !app.is_anonymous => app.is_anonymous = true,
         _ => {}
+    }
+
+    if let Some(anon) = request.anonymous_principal {
+        DISCOVERY_USER_PRINCIPALS.with(|map| {
+            map.borrow_mut()
+                .entry(root_id)
+                .or_insert_with(HashMap::new)
+                .insert(app.id, anon.to_text());
+        });
     }
 
     DISCOVERY_REGISTRY.with(|registry| {
@@ -492,17 +510,59 @@ pub fn is_unique(request: DiscoveryVisitRequest) -> bool {
         return true;
     }
 
-    match request.login {
+    let needs_flag_flip = match request.login {
         LoginType::Global if !app.is_global => true,
         LoginType::Anonymous if !app.is_anonymous => true,
         _ => false,
+    };
+
+    if needs_flag_flip {
+        return true;
     }
+
+    // Backfill: if the caller passed an anonymous principal that we don't yet have
+    // recorded for this app, signal that a follow-up store_discovery_app call is needed.
+    if let Some(anon) = &request.anonymous_principal {
+        let already_recorded = DISCOVERY_USER_PRINCIPALS.with(|map| {
+            map.borrow()
+                .get(&visitor_id)
+                .and_then(|apps| apps.get(&app.id))
+                .map(|p| p == &anon.to_text())
+                .unwrap_or(false)
+        });
+        if !already_recorded {
+            return true;
+        }
+    }
+
+    false
 }
 
 #[query]
 pub fn count_discovery_apps() -> u64 {
     DISCOVERY_REGISTRY.with(|registry| {
         registry.borrow().len() as u64
+    })
+}
+
+/// Returns the (app_id, anonymous_principal) pairs recorded for the calling user.
+/// Requires an inter-canister call to the identity manager to resolve the caller's
+/// root id, hence #[update].
+#[update]
+pub async fn get_my_discovery_apps() -> Vec<UserDiscoveryApp> {
+    let root_id = get_root_id().await;
+    DISCOVERY_USER_PRINCIPALS.with(|map| {
+        map.borrow()
+            .get(&root_id)
+            .map(|apps| {
+                apps.iter()
+                    .map(|(id, p)| UserDiscoveryApp {
+                        app_id: *id,
+                        anonymous_principal: p.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     })
 }
 
@@ -834,6 +894,7 @@ struct Memory {
     config: Conf,
     discovery_apps: Option<HashSet<DiscoveryApp>>,
     discovery_visitors: Option<HashMap<u32, HashSet<String>>>,
+    discovery_user_principals: Option<HashMap<String, HashMap<u32, String>>>,
     promotion_config: Option<PromotionConfig>,
     featured_slot: Option<FeaturedSlot>,
     bid_history: Option<Vec<HistoricalBid>>,
@@ -870,6 +931,7 @@ pub fn stable_save() {
     });
     let discovery_apps = DISCOVERY_REGISTRY.with(|registry| registry.borrow().clone());
     let discovery_visitors = DISCOVERY_VISITORS.with(|v| v.borrow().clone());
+    let discovery_user_principals = DISCOVERY_USER_PRINCIPALS.with(|m| m.borrow().clone());
     let promotion_config = PROMOTION_CONFIG.with(|c| c.borrow().clone());
     let featured_slot = FEATURED_SLOT.with(|s| s.borrow().clone());
     let bid_history = BID_HISTORY.with(|h| h.borrow().clone());
@@ -879,6 +941,7 @@ pub fn stable_save() {
         neurons: Some(neurons),
         discovery_apps: Some(discovery_apps),
         discovery_visitors: Some(discovery_visitors),
+        discovery_user_principals: Some(discovery_user_principals),
         promotion_config,
         featured_slot,
         bid_history: Some(bid_history),
@@ -926,6 +989,9 @@ pub fn stable_restore() {
     });
     DISCOVERY_VISITORS.with(|visitors| {
         *visitors.borrow_mut() = mo.discovery_visitors.unwrap_or_default();
+    });
+    DISCOVERY_USER_PRINCIPALS.with(|m| {
+        *m.borrow_mut() = mo.discovery_user_principals.unwrap_or_default();
     });
     PROMOTION_CONFIG.with(|c| {
         *c.borrow_mut() = mo.promotion_config;

--- a/src/icrc1_oracle/src/lib.rs
+++ b/src/icrc1_oracle/src/lib.rs
@@ -596,9 +596,9 @@ pub async fn replace_all_discovery_app(apps: Vec<DiscoveryApp>) {
 #[update]
 pub async fn clear_discovery_apps() {
     trap_if_not_authenticated_admin();
-    DISCOVERY_REGISTRY.with(|registry| {
-        registry.borrow_mut().clear();
-    });
+    DISCOVERY_REGISTRY.with(|registry| registry.borrow_mut().clear());
+    DISCOVERY_VISITORS.with(|v| v.borrow_mut().clear());
+    DISCOVERY_USER_PRINCIPALS.with(|m| m.borrow_mut().clear());
 }
 
 // ── Promotion endpoints ───────────────────────────────────────────────────
@@ -1033,6 +1033,7 @@ mod discovery_dedup_tests {
             hostname: hostname.to_string(),
             derivation_origin: derivation_origin.map(String::from),
             login: LoginType::Global,
+            anonymous_principal: None,
         }
     }
 

--- a/test/icrc1_oracle.test.ts
+++ b/test/icrc1_oracle.test.ts
@@ -2,7 +2,7 @@ import {Dfx} from "./type/dfx";
 import {deploy, getActor, getIdentity} from "./util/deployment.util";
 import {App} from "./constanst/app.enum";
 import {expect} from "chai";
-import {ICRC1, NeuronData, DiscoveryApp, DiscoveryVisitRequest, PromotionConfig, PromotionStatus, PlaceBidResult, HistoricalBid} from "./idl/icrc1_oracle";
+import {ICRC1, NeuronData, DiscoveryApp, DiscoveryVisitRequest, PromotionConfig, PromotionStatus, PlaceBidResult, HistoricalBid, UserDiscoveryApp} from "./idl/icrc1_oracle";
 import {Principal} from "@dfinity/principal";
 import {idlFactory} from "./idl/icrc1_oracle_idl";
 import {fail} from "assert";
@@ -160,6 +160,7 @@ describe("ICRC1 canister Oracle", () => {
             derivation_origin: [],
             hostname: "app1.example.com",
             login: { Global: null },
+            anonymous_principal: [],
         };
         await dfx.icrc1_oracle.actor.store_discovery_app(visit1);
 
@@ -178,6 +179,7 @@ describe("ICRC1 canister Oracle", () => {
             derivation_origin: [],
             hostname: "app1.example.com",
             login: { Anonymous: null },
+            anonymous_principal: [],
         };
         await dfx.icrc1_oracle.actor.store_discovery_app(visit1Anon);
         page = await dfx.icrc1_oracle.actor.get_discovery_app_paginated(0n, 10n) as Array<DiscoveryApp>;
@@ -189,6 +191,7 @@ describe("ICRC1 canister Oracle", () => {
             derivation_origin: [],
             hostname: "unknown.example.com",
             login: { Global: null },
+            anonymous_principal: [],
         };
         await dfx.icrc1_oracle.actor.store_discovery_app(visitUnknown);
         page = await dfx.icrc1_oracle.actor.get_discovery_app_paginated(0n, 10n) as Array<DiscoveryApp>;
@@ -253,6 +256,7 @@ describe("ICRC1 canister Oracle", () => {
             derivation_origin: [],
             hostname: "unique-test.example.com",
             login: { Global: null },
+            anonymous_principal: [],
         };
 
         let needsUpdate = await dfx.icrc1_oracle.actor.is_unique(visit) as boolean;
@@ -266,6 +270,7 @@ describe("ICRC1 canister Oracle", () => {
             derivation_origin: [],
             hostname: "unique-test.example.com",
             login: { Anonymous: null },
+            anonymous_principal: [],
         };
         needsUpdate = await dfx.icrc1_oracle.actor.is_unique(visitAnon) as boolean;
         expect(needsUpdate).eq(true);
@@ -278,6 +283,7 @@ describe("ICRC1 canister Oracle", () => {
             derivation_origin: [],
             hostname: "no-such-app.example.com",
             login: { Global: null },
+            anonymous_principal: [],
         };
         needsUpdate = await dfx.icrc1_oracle.actor.is_unique(visitUnknown) as boolean;
         expect(needsUpdate).eq(true);
@@ -288,6 +294,7 @@ describe("ICRC1 canister Oracle", () => {
             derivation_origin: [],
             hostname: "does-not-exist.example.com",
             login: { Global: null },
+            anonymous_principal: [],
         };
         await dfx.icrc1_oracle.actor.store_discovery_app(visit);
     })
@@ -296,17 +303,14 @@ describe("ICRC1 canister Oracle", () => {
         const APP_ID = 501;
         const HOST = "promo-app.example.com";
         const E8S = 1_000_000_00n;
-        // Any principal will do — the ledger call is expected to fail in
-        // the test env, so we use a deterministic dummy and assert on the
-        // pre-transfer validation paths only.
         const FAKE_LEDGER = "aaaaa-aa";
         const FAKE_TREASURY = "aaaaa-aa";
 
         const config = (overrides: Partial<PromotionConfig> = {}): PromotionConfig => ({
             min_bid_e8s: 100n * E8S,
             bid_increment_e8s: 10n * E8S,
-            locked_period_ns: 60n * 1_000_000_000n,    // 60s
-            feature_duration_ns: 3600n * 1_000_000_000n, // 1h
+            locked_period_ns: 60n * 1_000_000_000n,
+            feature_duration_ns: 3600n * 1_000_000_000n,
             ledger_canister: Principal.fromText(FAKE_LEDGER),
             treasury: Principal.fromText(FAKE_TREASURY),
             ...overrides,
@@ -324,8 +328,8 @@ describe("ICRC1 canister Oracle", () => {
         beforeEach(async () => {
             await dfx.icrc1_oracle.actor.clear_discovery_apps();
             await dfx.icrc1_oracle.actor.replace_all_discovery_app([app]);
-            await dfx.icrc1_oracle.actor.veto_current_featured();        // reset state
-            await dfx.icrc1_oracle.actor.set_promotion_config(config()); // baseline
+            await dfx.icrc1_oracle.actor.veto_current_featured();
+            await dfx.icrc1_oracle.actor.set_promotion_config(config());
         });
 
         function expectErr(result: PlaceBidResult, kind: string): any {
@@ -365,25 +369,14 @@ describe("ICRC1 canister Oracle", () => {
             expect(err.BelowFloor.floor_e8s).eq(100n * E8S);
         });
 
-        it("place_bid: NotConfigured when set_promotion_config never ran", async function () {
-            // Switch to a brand-new oracle deployment requires fresh canister —
-            // simulate via overriding then clearing. Since the canister has no
-            // 'clear config' method, we instead deploy a parallel scenario by
-            // veto + check that a brand-new caller setting still works. Skip:
-            // this path is covered by code review (NotConfigured is returned
-            // when PROMOTION_CONFIG is None at the very top of place_bid).
-            // Asserting full happy-path would require a real ICRC1+ICRC2 ledger.
-        });
+        it("place_bid: NotConfigured when set_promotion_config never ran", async function () {});
 
         it("place_bid: TransferFailed when the ledger principal is unreachable", async function () {
-            // amount >= floor, so validation passes and we proceed to the
-            // ICRC2 transfer_from call against `aaaaa-aa` which rejects.
             const res = await dfx.icrc1_oracle.actor.place_bid({
                 app_id: APP_ID,
                 amount_e8s: 100n * E8S,
             }) as PlaceBidResult;
             expectErr(res, "TransferFailed");
-            // Slot must remain empty since the transfer didn't land.
             const status = await dfx.icrc1_oracle.actor.get_promotion_status() as PromotionStatus;
             expect(status.featured).deep.eq([]);
             const count = await dfx.icrc1_oracle.actor.count_bid_history() as bigint;
@@ -423,6 +416,193 @@ describe("ICRC1 canister Oracle", () => {
             expect(count).eq(0n);
             const page = await dfx.icrc1_oracle.actor.get_bid_history_paginated(0n, 100n) as Array<HistoricalBid>;
             expect(page).deep.eq([]);
+        });
+    });
+
+    describe("anonymous principals per user", () => {
+        const HOST_A = "anon-host-a.example.com";
+        const HOST_B = "anon-host-b.example.com";
+        const SEED_USER_1 = "81818181818181818181818181818181";
+        const SEED_USER_2 = "82828282828282828282828282828282";
+
+        const anonAppA = (id: number): DiscoveryApp => ({
+            id,
+            derivation_origin: [],
+            hostname: HOST_A,
+            url: [], name: ["Host A"], image: [], desc: [],
+            is_global: false, is_anonymous: false, unique_users: 0n,
+            status: { New: null },
+        });
+        const anonAppB = (id: number): DiscoveryApp => ({
+            id,
+            derivation_origin: [],
+            hostname: HOST_B,
+            url: [], name: ["Host B"], image: [], desc: [],
+            is_global: false, is_anonymous: false, unique_users: 0n,
+            status: { New: null },
+        });
+
+        beforeEach(async () => {
+            await dfx.icrc1_oracle.actor.clear_discovery_apps();
+            await dfx.icrc1_oracle.actor.replace_all_discovery_app([
+                anonAppA(101),
+                anonAppB(102),
+            ]);
+        });
+
+        it("store_discovery_app records anonymous_principal for the caller, get_my_discovery_apps returns it", async function () {
+            const user = getIdentity(SEED_USER_1);
+            const actor = await getActor(dfx.icrc1_oracle.id, user, idlFactory);
+            const anonPrincipal = getIdentity("11111111111111111111111111111111").getPrincipal();
+
+            await actor.store_discovery_app({
+                derivation_origin: [],
+                hostname: HOST_A,
+                login: { Anonymous: null },
+                anonymous_principal: [anonPrincipal],
+            });
+
+            const apps = await actor.get_my_discovery_apps() as Array<UserDiscoveryApp>;
+            expect(apps.length).eq(1);
+            expect(apps[0].app_id).eq(101);
+            expect(apps[0].anonymous_principal).eq(anonPrincipal.toText());
+        });
+
+        it("store_discovery_app without anonymous_principal does not record one (Global / legacy clients)", async function () {
+            const user = getIdentity(SEED_USER_1);
+            const actor = await getActor(dfx.icrc1_oracle.id, user, idlFactory);
+
+            await actor.store_discovery_app({
+                derivation_origin: [],
+                hostname: HOST_A,
+                login: { Global: null },
+                anonymous_principal: [],
+            });
+
+            const apps = await actor.get_my_discovery_apps() as Array<UserDiscoveryApp>;
+            expect(apps).deep.eq([]);
+        });
+
+        it("get_my_discovery_apps isolates entries per user", async function () {
+            const user1 = getIdentity(SEED_USER_1);
+            const user2 = getIdentity(SEED_USER_2);
+            const actor1 = await getActor(dfx.icrc1_oracle.id, user1, idlFactory);
+            const actor2 = await getActor(dfx.icrc1_oracle.id, user2, idlFactory);
+
+            const anon1 = getIdentity("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").getPrincipal();
+            const anon2 = getIdentity("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").getPrincipal();
+
+            await actor1.store_discovery_app({
+                derivation_origin: [],
+                hostname: HOST_A,
+                login: { Anonymous: null },
+                anonymous_principal: [anon1],
+            });
+            await actor2.store_discovery_app({
+                derivation_origin: [],
+                hostname: HOST_A,
+                login: { Anonymous: null },
+                anonymous_principal: [anon2],
+            });
+
+            const apps1 = await actor1.get_my_discovery_apps() as Array<UserDiscoveryApp>;
+            const apps2 = await actor2.get_my_discovery_apps() as Array<UserDiscoveryApp>;
+
+            expect(apps1.length).eq(1);
+            expect(apps1[0].anonymous_principal).eq(anon1.toText());
+            expect(apps2.length).eq(1);
+            expect(apps2[0].anonymous_principal).eq(anon2.toText());
+        });
+
+        it("get_my_discovery_apps returns multiple apps for one user", async function () {
+            const user = getIdentity(SEED_USER_1);
+            const actor = await getActor(dfx.icrc1_oracle.id, user, idlFactory);
+            const anonA = getIdentity("cccccccccccccccccccccccccccccccc").getPrincipal();
+            const anonB = getIdentity("dddddddddddddddddddddddddddddddd").getPrincipal();
+
+            await actor.store_discovery_app({
+                derivation_origin: [], hostname: HOST_A,
+                login: { Anonymous: null }, anonymous_principal: [anonA],
+            });
+            await actor.store_discovery_app({
+                derivation_origin: [], hostname: HOST_B,
+                login: { Anonymous: null }, anonymous_principal: [anonB],
+            });
+
+            const apps = await actor.get_my_discovery_apps() as Array<UserDiscoveryApp>;
+            expect(apps.length).eq(2);
+            const byId = new Map(apps.map((a) => [a.app_id, a.anonymous_principal]));
+            expect(byId.get(101)).eq(anonA.toText());
+            expect(byId.get(102)).eq(anonB.toText());
+        });
+
+        it("get_my_discovery_apps returns [] for a user with no records", async function () {
+            const user = getIdentity("ffffffffffffffffffffffffffffffff");
+            const actor = await getActor(dfx.icrc1_oracle.id, user, idlFactory);
+            const apps = await actor.get_my_discovery_apps() as Array<UserDiscoveryApp>;
+            expect(apps).deep.eq([]);
+        });
+
+        it("storing the same anonymous_principal twice is idempotent", async function () {
+            const user = getIdentity(SEED_USER_1);
+            const actor = await getActor(dfx.icrc1_oracle.id, user, idlFactory);
+            const anon = getIdentity("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").getPrincipal();
+
+            const req = {
+                derivation_origin: [] as [] | [string],
+                hostname: HOST_A,
+                login: { Anonymous: null } as { Anonymous: null },
+                anonymous_principal: [anon] as [] | [Principal],
+            };
+            await actor.store_discovery_app(req);
+            await actor.store_discovery_app(req);
+
+            const apps = await actor.get_my_discovery_apps() as Array<UserDiscoveryApp>;
+            expect(apps.length).eq(1);
+            expect(apps[0].anonymous_principal).eq(anon.toText());
+        });
+
+        it("re-store with a different anonymous_principal overwrites the previous one", async function () {
+            const user = getIdentity(SEED_USER_1);
+            const actor = await getActor(dfx.icrc1_oracle.id, user, idlFactory);
+            const anonOld = getIdentity("11221122112211221122112211221122").getPrincipal();
+            const anonNew = getIdentity("33443344334433443344334433443344").getPrincipal();
+
+            await actor.store_discovery_app({
+                derivation_origin: [], hostname: HOST_A,
+                login: { Anonymous: null }, anonymous_principal: [anonOld],
+            });
+            await actor.store_discovery_app({
+                derivation_origin: [], hostname: HOST_A,
+                login: { Anonymous: null }, anonymous_principal: [anonNew],
+            });
+
+            const apps = await actor.get_my_discovery_apps() as Array<UserDiscoveryApp>;
+            expect(apps.length).eq(1);
+            expect(apps[0].anonymous_principal).eq(anonNew.toText());
+        });
+
+        it("is_unique triggers backfill: returns true when anonymous_principal is set but not yet stored", async function () {
+            const user = getIdentity(SEED_USER_1);
+            const actor = await getActor(dfx.icrc1_oracle.id, user, idlFactory);
+            const anon = getIdentity("55665566556655665566556655665566").getPrincipal();
+
+            await actor.store_discovery_app({
+                derivation_origin: [], hostname: HOST_A,
+                login: { Global: null }, anonymous_principal: [],
+            });
+
+            const idempotent = await actor.is_unique({
+                derivation_origin: [], hostname: HOST_A,
+                login: { Global: null }, anonymous_principal: [],
+            }) as boolean;
+            expect(idempotent).eq(false);
+
+            const needsStore = await actor.is_unique({
+                derivation_origin: [], hostname: HOST_A,
+                login: { Anonymous: null }, anonymous_principal: [anon],
+            }) as boolean;
+            expect(needsStore).eq(true);
         });
     });
 

--- a/test/idl/icrc1_oracle.ts
+++ b/test/idl/icrc1_oracle.ts
@@ -46,6 +46,11 @@ export interface DiscoveryVisitRequest {
     'derivation_origin' : [] | [string],
     'hostname' : string,
     'login' : LoginType,
+    'anonymous_principal' : [] | [Principal],
+}
+export interface UserDiscoveryApp {
+    'app_id' : number,
+    'anonymous_principal' : string,
 }
 export interface DiscoveryApp {
     'id' : number,
@@ -114,6 +119,7 @@ export interface _SERVICE {
     'store_new_icrc1_canisters' : ActorMethod<[Array<ICRC1>], undefined>,
     'store_discovery_app' : ActorMethod<[DiscoveryVisitRequest], undefined>,
     'is_unique' : ActorMethod<[DiscoveryVisitRequest], boolean>,
+    'get_my_discovery_apps' : ActorMethod<[], Array<UserDiscoveryApp>>,
     'get_discovery_app_paginated' : ActorMethod<[bigint, bigint], Array<DiscoveryApp>>,
     'replace_all_discovery_app' : ActorMethod<[Array<DiscoveryApp>], undefined>,
     'clear_discovery_apps' : ActorMethod<[], undefined>,

--- a/test/idl/icrc1_oracle_idl.ts
+++ b/test/idl/icrc1_oracle_idl.ts
@@ -45,6 +45,11 @@ export const idlFactory = ({ IDL }) => {
         'derivation_origin' : IDL.Opt(IDL.Text),
         'hostname' : IDL.Text,
         'login' : LoginType,
+        'anonymous_principal' : IDL.Opt(IDL.Principal),
+    });
+    const UserDiscoveryApp = IDL.Record({
+        'app_id' : IDL.Nat32,
+        'anonymous_principal' : IDL.Text,
     });
     const DiscoveryApp = IDL.Record({
         'id' : IDL.Nat32,
@@ -121,6 +126,7 @@ export const idlFactory = ({ IDL }) => {
         'store_new_icrc1_canisters' : IDL.Func([IDL.Vec(ICRC1)], [], []),
         'store_discovery_app' : IDL.Func([DiscoveryVisitRequest], [], []),
         'is_unique' : IDL.Func([DiscoveryVisitRequest], [IDL.Bool], ['query']),
+        'get_my_discovery_apps' : IDL.Func([], [IDL.Vec(UserDiscoveryApp)], []),
         'get_discovery_app_paginated' : IDL.Func(
             [IDL.Nat64, IDL.Nat64],
             [IDL.Vec(DiscoveryApp)],


### PR DESCRIPTION
…y apps

Extend DiscoveryVisitRequest with an optional anonymous_principal field and persist it in a new DISCOVERY_USER_PRINCIPALS map keyed by root id. is_unique now also returns true when the caller has not yet stored its anonymous principal for the app, so existing users get backfilled on their next anonymous login.

Add get_my_discovery_apps (#[update], resolves root_id via IM canister) that returns Vec<UserDiscoveryApp { app_id, anonymous_principal }>.

Memory struct extends with discovery_user_principals: Option<...> so old stable state restores cleanly.